### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,16 @@ const tns = require(pathToPackage);
 
 Load all available extensions
 ```JavaScript
-tns.extensibilityService.loadExtensions();
+/**
+     * @name loadExtensions
+     * @description Loads all currently installed extensions
+     * @return {Promise<any>[]} - On Success: Array of Promises, one for each installed extension
+*/
+Promise.all(tns.extensibilityService.loadExtensions()).then((loadedExtensions) => {
+    console.log("All extensions loaded successfully!");
+}).catch((error) => {
+    console.error(error);
+});
 ```
 
 ##### Get details for all installed templates

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ Install the npm package
 $ tns extension install <path to nativescript-starter-kits>.tgz
 ```
 ## Public API
+Get proper `nativescript` reference
 ```JavaScript
-const tns = require("nativescript");
+const pathToPackage = require("global-modules-path").getPath("nativescript", "tns");
+const tns = require(pathToPackage);
 
 ```
 


### PR DESCRIPTION
I kept receiving exception that some `.common/bootstrap` module was not found.
I was trying to run my testing.ts script inside the nativescript-starter-kits/ folder. I guess that `const tns = require("nativescript");` was searching in the wrong place.

https://www.npmjs.com/package/global-modules-path