### PR TITLE
Modify tests to use chaiAsPromised

### DIFF
--- a/lib/definitions/git-service.d.ts
+++ b/lib/definitions/git-service.d.ts
@@ -1,4 +1,5 @@
 interface IGitService {
     getPackageJsonFromSource(templateName: string): Promise<any>;
     getAssetsContent(templateName: string): Promise<any>;
+    clonePageTemplate(pageName: string, flavor: string, templatesDirectory: string): Promise<string>;
 }

--- a/lib/services/git-service.ts
+++ b/lib/services/git-service.ts
@@ -1,3 +1,4 @@
+import { Config } from "../shared/config";
 import util from "../shared/util";
 
 export class GitService implements IGitService {
@@ -60,7 +61,7 @@ export class GitService implements IGitService {
         const commandArguments: Array<any> = ["clone"];
 
         return new Promise((resolve, reject) => {
-            util.getPageTemplatesBaseUrl(flavor)
+            this.getPageTemplatesBaseUrl(flavor)
                 .then((baseUrl: string) => {
                     baseUrl = baseUrl + ".git";
                     commandArguments.push(baseUrl);
@@ -79,6 +80,30 @@ export class GitService implements IGitService {
                 .catch((downloadPageError: any) => {
                     reject(downloadPageError);
                 });
+        });
+    }
+
+    private getPageTemplatesBaseUrl(flavor: string) {
+        let baseUrl: string;
+
+        return new Promise((resolve, reject) => {
+            switch (flavor) {
+                case "JavaScript":
+                    baseUrl = util.format(Config.orgBaseUrl, "nativescript-page-templates");
+                    resolve(baseUrl);
+                    break;
+
+                case "TypeScript":
+                    baseUrl = util.format(Config.orgBaseUrl, "nativescript-page-templates-ts");
+                    resolve(baseUrl);
+                    break;
+                case "Angular & TypeScript":
+                    baseUrl = util.format(Config.orgBaseUrl, "nativescript-page-templates-ng");
+                    resolve(baseUrl);
+                    break;
+                default:
+                    reject(new Error("Bad Flavor"));
+            }
         });
     }
 

--- a/lib/services/git-service.ts
+++ b/lib/services/git-service.ts
@@ -55,6 +55,33 @@ export class GitService implements IGitService {
             });
     }
 
+    clonePageTemplate(pageName: string, flavor: string, templatesDirectory: string): Promise<string> {
+        const command = "git";
+        const commandArguments: Array<any> = ["clone"];
+
+        return new Promise((resolve, reject) => {
+            util.getPageTemplatesBaseUrl(flavor)
+                .then((baseUrl: string) => {
+                    baseUrl = baseUrl + ".git";
+                    commandArguments.push(baseUrl);
+                    commandArguments.push(templatesDirectory);
+
+                    const process = util.childProcess.spawn(command, commandArguments);
+                    process.on("close", (code) => {
+                        if (code !== 0) {
+                            return Promise.reject(new Error(`child process exited with code ${code}`));
+                        }
+
+                        const pagePath = util.path.join(templatesDirectory, pageName);
+                        resolve(pagePath);
+                    });
+                })
+                .catch((downloadPageError: any) => {
+                    reject(downloadPageError);
+                });
+        });
+    }
+
     private getResourcesFromSource(templateName: string, assetDictionary: any) {
         const content: any = {};
         const promises: Array<any> = [];

--- a/lib/services/page-service.ts
+++ b/lib/services/page-service.ts
@@ -7,6 +7,10 @@ const BACKUP = require("../../consts/pages-backup-data");
 const ejs = require("ejs");
 
 export class PageService implements IPageService {
+
+    constructor(private $gitService: IGitService) {
+    }
+
     getPages() {
         return new Promise((resolve, reject) => {
             resolve(BACKUP.fallback);
@@ -28,7 +32,7 @@ export class PageService implements IPageService {
                         return Promise.reject(new Error(`Page with the name "${pageName}" already exists`));
                     }
 
-                    return this.clonePageTemplate(displayName, pageTemplate.templateFlavor, pagesDirectory);
+                    return this.$gitService.clonePageTemplate(displayName, pageTemplate.templateFlavor, pagesDirectory);
                 })
                 .then((downloadPath: any) => {
                     return this.createPage(downloadPath, newPageDirectory, pageName);
@@ -38,33 +42,6 @@ export class PageService implements IPageService {
                 })
                 .catch((promiseError: any) => {
                     reject(promiseError);
-                });
-        });
-    }
-
-    private clonePageTemplate(pageName: string, flavor: string, templatesDirectory: string): Promise<string> {
-        const command = "git";
-        const commandArguments: Array<any> = ["clone"];
-
-        return new Promise((resolve, reject) => {
-            util.getPageTemplatesBaseUrl(flavor)
-                .then((baseUrl: string) => {
-                    baseUrl = baseUrl + ".git";
-                    commandArguments.push(baseUrl);
-                    commandArguments.push(templatesDirectory);
-
-                    const process = util.childProcess.spawn(command, commandArguments);
-                    process.on("close", (code) => {
-                        if (code !== 0) {
-                            return Promise.reject(new Error(`child process exited with code ${code}`));
-                        }
-
-                        const pagePath = util.path.join(templatesDirectory, pageName);
-                        resolve(pagePath);
-                    });
-                })
-                .catch((downloadPageError: any) => {
-                    reject(downloadPageError);
                 });
         });
     }

--- a/lib/services/template-service.ts
+++ b/lib/services/template-service.ts
@@ -106,6 +106,8 @@ export class TemplateService implements ITemplateService {
                         // Load data from cache
                         resolve(value);
                     }
+                } else {
+                    resolve(BACKUP.fallback);
                 }
             });
         });

--- a/lib/services/template-service.ts
+++ b/lib/services/template-service.ts
@@ -3,10 +3,12 @@ import { Config } from "../shared/config";
 const _ = require("lodash");
 const BACKUP = require("../../consts/templates-backup-data");
 const nodeCache = require("node-cache");
-const templateCache = new nodeCache();
 
 export class TemplateService implements ITemplateService {
+    templateCache: any;
+
     constructor(private $gitService: IGitService) {
+        this.templateCache = new nodeCache();
     }
 
     checkTemplateFlavor(packageJson: any) {
@@ -27,8 +29,8 @@ export class TemplateService implements ITemplateService {
         const meta: any = {};
 
         return new Promise((resolve, reject) => {
-            if (typeof packageJson === "undefined") {
-                reject({message: "Missing package.json"});
+            if (_.isEmpty(packageJson)) {
+                reject(new Error("Missing or invalid package.json provided"));
             } else {
                 meta.name = packageJson.name;
                 meta.displayName = packageJson.displayName;
@@ -70,10 +72,7 @@ export class TemplateService implements ITemplateService {
                             resolve(templateDetails);
                         })
                         .catch((error) => {
-                            reject({
-                                message: "Error retrieving data for " + templateName,
-                                error
-                            });
+                            reject(error);
                         });
                 })
                 .catch((error: any) => {
@@ -83,37 +82,26 @@ export class TemplateService implements ITemplateService {
     }
 
     getTemplates(): Promise<Array<any>> {
-        let templateDetails: Array<any> = [];
         const promises: Array<any> = [];
 
         return new Promise((resolve, reject) => {
-            templateCache.get("templateDetails", (error: any, value: any) => {
+            this.templateCache.get("templateDetails", (error: any, value: any) => {
                 if (!error) {
                     if (value === undefined) {
                         Config.availableTemplateRepos.forEach((name: string) => {
-                            promises.push(
-                                this.getAppTemplateDetails(name)
-                                    .then((details) => {
-                                        templateDetails.push(details);
-                                    })
-                                    .catch((errorDetails) => {
-                                        reject(errorDetails);
-                                    })
-                            );
+                            promises.push(this.getAppTemplateDetails(name));
                         });
 
                         Promise.all(promises)
-                            .then(() => {
-                                templateDetails = this.sortTemplateData(templateDetails);
-                                templateCache.set("templateDetails", templateDetails, Config.cacheTime);
-                                resolve(templateDetails);
-
+                            .then((resultTemplateDetails: Array<any>) => {
+                                resultTemplateDetails = this.sortTemplateData(resultTemplateDetails);
+                                this.templateCache.set("templateDetails", resultTemplateDetails, Config.cacheTime);
+                                resolve(resultTemplateDetails);
                             })
                             .catch((errorPromises: any) => {
                                 // TODO Implement error logger
                                 resolve(BACKUP.fallback);
                             });
-
                     } else {
                         // Load data from cache
                         resolve(value);

--- a/lib/shared/util.ts
+++ b/lib/shared/util.ts
@@ -1,7 +1,6 @@
 import * as childProcess from "child_process";
 import * as path from "path";
 import * as nodeUtil from "util";
-import { Config } from "./config";
 
 const request = require("request-promise");
 const fs = require("fs-extra");
@@ -32,30 +31,6 @@ export default class Util {
                     resolve(false);
                 }
             });
-        });
-    }
-
-    static getPageTemplatesBaseUrl(flavor: string) {
-        let baseUrl: string;
-
-        return new Promise((resolve, reject) => {
-            switch (flavor) {
-                case "JavaScript":
-                    baseUrl = this.format(Config.orgBaseUrl, "nativescript-page-templates");
-                    resolve(baseUrl);
-                    break;
-
-                case "TypeScript":
-                    baseUrl = this.format(Config.orgBaseUrl, "nativescript-page-templates-ts");
-                    resolve(baseUrl);
-                    break;
-                case "Angular & TypeScript":
-                    baseUrl = this.format(Config.orgBaseUrl, "nativescript-page-templates-ng");
-                    resolve(baseUrl);
-                    break;
-                default:
-                    reject(new Error("Bad Flavor"));
-            }
         });
     }
 }

--- a/package.json
+++ b/package.json
@@ -42,11 +42,13 @@
     "typescript": "2.4.1"
   },
   "dependencies": {
+    "chai-as-promised": "^6.0.0",
     "ejs": "^2.5.7",
     "fs-extra": "^4.0.1",
     "lodash": "4.13.1",
     "node-cache": "^4.1.1",
     "request": "^2.81.0",
-    "request-promise": "^4.2.1"
+    "request-promise": "^4.2.1",
+    "sinon": "^3.3.0"
   }
 }

--- a/test/test-page-backup.ts
+++ b/test/test-page-backup.ts
@@ -1,30 +1,38 @@
 import * as chai from "chai";
 const expect = chai.expect;
 const templateBackup = require("../consts/pages-backup-data").fallback;
+const chaiAsPromised = require("chai-as-promised");
+const chaiThings = require("chai-things");
 
-chai.use(require("chai-things"));
+chai.use(chaiAsPromised);
+chai.use(chaiThings);
 
 describe("Page backup data", () => {
 
     describe("Check page backup data integrity", () => {
         it("Should be an Array of Objects", () => {
-            expect(templateBackup).to.be.an("array");
-            templateBackup.should.all.have.property("name");
-            templateBackup.should.all.have.property("description");
-            templateBackup.should.all.have.property("displayName");
-            templateBackup.should.all.have.property("gitUrl");
-            templateBackup.should.all.have.property("version");
-            templateBackup.should.all.have.property("templateFlavor");
-            templateBackup.should.all.have.property("type");
+            return expect(Promise.resolve(templateBackup))
+                .to.eventually.be.an("array").then((array) => {
+                    array.forEach((item: any) => {
+                        expect(item).to.have.property("name");
+                        expect(item).to.have.property("description");
+                        expect(item).to.have.property("displayName");
+                        expect(item).to.have.property("gitUrl");
+                        expect(item).to.have.property("version");
+                        expect(item).to.have.property("templateFlavor");
+                        expect(item).to.have.property("type");
+                    });
+                });
         });
-    });
 
-    describe("Check page backup data name property", () => {
-        it("names should start with tns-", () => {
-            for (const template of templateBackup) {
-                template.name.should.be.a("string");
-                expect(template.name).to.match(/tns-/);
-            }
+        it("Should have proper name string", () => {
+            return expect(Promise.resolve(templateBackup))
+                .to.eventually.be.an("array").then((array) => {
+                    array.forEach((item: any) => {
+                        expect(item.name).to.match(/tns-/);
+                        expect(item.name).to.be.a("string");
+                    });
+                });
         });
     });
 });

--- a/test/test-page-service.ts
+++ b/test/test-page-service.ts
@@ -1,0 +1,102 @@
+import { Yok } from "mobile-cli-lib/yok";
+import { PageService } from "../lib/services/page-service";
+import { GitService } from "../lib/services/git-service";
+// import { Config } from "../lib/shared/config";
+import util from "../lib/shared/util";
+
+// const pagesBackup = require("../consts/pages-backup-data").fallback;
+const chai = require("chai");
+const chaiAsPromised = require("chai-as-promised");
+const expect = chai.expect;
+const sinon = require("sinon");
+
+chai.use(chaiAsPromised);
+
+let testInjector: any;
+
+describe("PageService Api", () => {
+    let gitService: GitService;
+    let pageService: PageService;
+
+    const pageName = "dummyPageName";
+    const appPath = "dummyPath";
+
+    const pageTemplate = {
+        name: "tns-page-dummy",
+        displayName: "Dummy",
+        description: "dummyDescription",
+        version: "1.0",
+        gitUrl: "dummyUrl",
+        templateFlavor: "dummyFlavor",
+        type: "Page template"
+    };
+
+    beforeEach(() => {
+        gitService = new GitService();
+        pageService = new PageService(gitService);
+        testInjector = new Yok();
+
+        testInjector.register("pageService", PageService);
+    });
+
+    describe("Add page", () => {
+        let sandbox: any;
+
+        beforeEach(() => {
+            sandbox = sinon.sandbox.create();
+        });
+
+        afterEach(() => sandbox.restore());
+
+        it("Should be rejected if page already exists", () => {
+            const pageExistError = new Error(`Page with the name "${pageName}" already exists`);
+
+            sandbox.stub(util.fs, "emptyDir")
+                .returns(Promise.resolve());
+
+            sandbox.stub(util, "pageExists")
+                .returns(Promise.resolve(true));
+
+            return expect(pageService.addPage(pageName, pageTemplate, appPath))
+                .to.eventually.be.rejectedWith(pageExistError.message)
+                .be.an.instanceOf(Error);
+        });
+
+        it("Should be rejected if page repository clone failed", () => {
+            const pageCloneError = new Error("Error");
+
+            sandbox.stub(util.fs, "emptyDir")
+                .returns(Promise.resolve());
+
+            sandbox.stub(util, "pageExists")
+                .returns(Promise.resolve(false));
+
+            sandbox.stub(gitService, "clonePageTemplate")
+                .returns(Promise.reject(pageCloneError));
+
+            return expect(pageService.addPage(pageName, pageTemplate, appPath))
+                .to.eventually.be.rejectedWith(pageCloneError.message)
+                .be.an.instanceOf(Error);
+        });
+
+        it("Should return the newly created page directory path", () => {
+            const newPageDirectory = "dummyDirectory";
+            const clonedPagesDirectory = "dummyClonedPagesDirecotyr";
+
+            sandbox.stub(util.fs, "emptyDir")
+                .returns(Promise.resolve());
+
+            sandbox.stub(util, "pageExists")
+                .returns(Promise.resolve(false));
+
+            sandbox.stub(gitService, "clonePageTemplate")
+                .returns(Promise.resolve(clonedPagesDirectory));
+
+            sandbox.stub(pageService, "createPage")
+                .returns(Promise.resolve(newPageDirectory));
+
+            return expect(pageService.addPage(pageName, pageTemplate, appPath))
+                .to.eventually.be.an("string", newPageDirectory);
+        });
+    });
+});

--- a/test/test-page-service.ts
+++ b/test/test-page-service.ts
@@ -1,10 +1,8 @@
 import { Yok } from "mobile-cli-lib/yok";
-import { PageService } from "../lib/services/page-service";
 import { GitService } from "../lib/services/git-service";
-// import { Config } from "../lib/shared/config";
+import { PageService } from "../lib/services/page-service";
 import util from "../lib/shared/util";
 
-// const pagesBackup = require("../consts/pages-backup-data").fallback;
 const chai = require("chai");
 const chaiAsPromised = require("chai-as-promised");
 const expect = chai.expect;

--- a/test/test-template-backup.ts
+++ b/test/test-template-backup.ts
@@ -1,45 +1,54 @@
 import * as chai from "chai";
 import { Config } from "../lib/shared/config";
+
 const expect = chai.expect;
 const templateBackup = require("../consts/templates-backup-data").fallback;
+const chaiAsPromised = require("chai-as-promised");
 
-chai.use(require("chai-things"));
+chai.use(chaiAsPromised);
 
 describe("Template backup data", () => {
 
     describe("Check template backup data integrity", () => {
         it("Should be an Array of Objects", () => {
-            expect(templateBackup).to.be.an("array");
-            expect(templateBackup).to.have.length(Config.availableTemplateRepos.length);
-            templateBackup.should.all.have.property("name");
-            templateBackup.should.all.have.property("description");
-            templateBackup.should.all.have.property("displayName");
-            templateBackup.should.all.have.property("gitUrl");
-            templateBackup.should.all.have.property("version");
-            templateBackup.should.all.have.property("templateFlavor");
-            templateBackup.should.all.have.property("type");
-            templateBackup.should.all.have.property("resources");
+            return expect(Promise.resolve(templateBackup))
+                .to.eventually.be.an("array")
+                .to.have.length(Config.availableTemplateRepos.length).then((array) => {
+                    array.forEach((item: any) => {
+                        expect(item).to.have.property("name");
+                        expect(item).to.have.property("description");
+                        expect(item).to.have.property("displayName");
+                        expect(item).to.have.property("gitUrl");
+                        expect(item).to.have.property("version");
+                        expect(item).to.have.property("templateFlavor");
+                        expect(item).to.have.property("type");
+                        expect(item).to.have.property("resources");
+                    });
+                });
         });
 
         it("Should have platform specific, base64 encoded resource images", () => {
-           for (const template of templateBackup) {
-               expect(template.resources).to.have.property("android");
-               expect(template.resources).to.have.property("ios");
-               expect(template.resources).to.have.property("thumbnail");
-
-               expect(template.resources.android).to.match(/data:image\/png;base64/);
-               expect(template.resources.ios).to.match(/data:image\/png;base64/);
-               expect(template.resources.thumbnail).to.match(/data:image\/png;base64/);
-           }
+            return expect(Promise.resolve(templateBackup))
+                .to.eventually.be.an("array").then((array) => {
+                    array.forEach((item: any) => {
+                        expect(item.resources).to.have.property("android");
+                        expect(item.resources).to.have.property("ios");
+                        expect(item.resources).to.have.property("thumbnail");
+                        expect(item.resources.android).to.match(/data:image\/png;base64/);
+                        expect(item.resources.ios).to.match(/data:image\/png;base64/);
+                        expect(item.resources.thumbnail).to.match(/data:image\/png;base64/);
+                    });
+                });
         });
-    });
 
-    describe("Check template backup data name property", () => {
-        it("names should start with tns-", () => {
-            for (const template of templateBackup) {
-                template.name.should.be.a("string");
-                expect(template.name).to.match(/tns-/);
-            }
+        it("Should have proper name string", () => {
+            return expect(Promise.resolve(templateBackup))
+                .to.eventually.be.an("array").then((array) => {
+                    array.forEach((item: any) => {
+                        expect(item.name).to.match(/tns-/);
+                        expect(item.name).to.be.a("string");
+                    });
+                });
         });
     });
 });

--- a/test/test-template-service.ts
+++ b/test/test-template-service.ts
@@ -1,90 +1,215 @@
 import { Yok } from "mobile-cli-lib/yok";
 import { GitService } from "../lib/services/git-service";
 import { TemplateService } from "../lib/services/template-service";
+import { Config } from "../lib/shared/config";
 
+const templateBackup = require("../consts/templates-backup-data").fallback;
 const chai = require("chai");
-const should = require("chai").should();
+const chaiAsPromised = require("chai-as-promised");
+const expect = chai.expect;
+const sinon = require("sinon");
 
-chai.use(require("chai-things"));
+chai.use(chaiAsPromised);
 
 let testInjector: any;
 
 describe("TemplateService Api", () => {
+    let gitService: GitService;
+    let templateService: TemplateService;
+
+    const packageJson = {
+        name: "dummyName",
+        displayName: "dummyDisplayName",
+        version: "1.0",
+        description: "dummyDescription",
+        repository: {
+            url: "dummyUrl"
+        },
+        templateType: "dummyType"
+    };
+
+    const appTemplate = {
+        name: "tns-template-dummy-name",
+        displayName: "dummyDisplayName",
+        version: "1.0",
+        description: "dummyDescription",
+        gitUrl: "dummyUrl",
+        templateType: "dummyType",
+        type: "App template",
+        resources: {
+            android: "android",
+            ios: "ios",
+            thumbnail: "dummyThumbnail"
+        }
+    };
+
     beforeEach(() => {
+        gitService = new GitService();
+        templateService = new TemplateService(gitService);
+
         testInjector = new Yok();
         testInjector.register("templateService", TemplateService);
         testInjector.register("gitService", GitService);
     });
 
     describe("Check template flavor", () => {
-        const gitService = new GitService();
-        const templateService = new TemplateService(gitService);
-        it("Returns a template flavor", () => {
-            templateService.checkTemplateFlavor({name: "template-hello-world-ng"}).then((flavor) => {
-                flavor.should.be.a("string");
-                flavor.should.not.be.an("object");
-                flavor.should.not.be.a("number");
-                flavor.should.not.be.instanceOf(Error);
-            });
+        it("Should be rejected when no packageJson provided", () => {
+            return expect(templateService.checkTemplateFlavor({}))
+                .to.eventually.be.rejectedWith("Cannot read template details")
+                .be.an.instanceOf(Error);
         });
 
-        it("handles errors gracefully ", () => {
-            templateService.checkTemplateFlavor({}).then((flavor) => {
-                should.fail(flavor, null, "flavor should not be returned");
-            }, (errorFlavor) => {
-                errorFlavor.should.be.instanceOf(Error);
-            });
+        it("Should be rejected when no valid packageJson provided", () => {
+            return expect(templateService.checkTemplateFlavor({ noName: "template-hello-world-ng" }))
+                .to.eventually.be.rejectedWith("Cannot read template details")
+                .be.an.instanceOf(Error);
         });
 
+        it("Should return template flavor", () => {
+            return expect(templateService.checkTemplateFlavor({ name: "template-hello-world-ng" }))
+                .to.eventually.be.fulfilled
+                .to.be.equal("Angular & TypeScript");
+        });
     });
 
-    describe("Get App template Details", () => {
-        const gitService = new GitService();
-        const templateService = new TemplateService(gitService);
-        it("Returns a Template Details object via a Promise", () => {
-            templateService.getAppTemplateDetails("template-hello-world-ng").then((details) => {
-                should.exist(details);
-                details.should.be.an("object");
-                details.should.have.property("name");
-                details.should.have.property("description");
-                details.should.have.property("version");
-                details.should.have.property("templateFlavor");
-                details.should.not.be.instanceOf(Error);
-
-            }).catch((err) => {
-                should.not.exist(err);
-            });
+    describe("Get template metadata", () => {
+        it("Should be rejected when no packageJson provided", () => {
+            return expect(templateService.getTemplateMetaData({}))
+                .to.eventually.be.rejectedWith("Missing or invalid package.json provided")
+                .be.an.instanceOf(Error);
         });
 
-        it("It handles error trough Promise Reject", () => {
-            templateService.getAppTemplateDetails("template-hello-world-ng").then((details) => {
-                should.not.exist(details);
-            }).catch((err) => {
-                should.exist(err);
-                err.should.be.instanceOf(Error);
-            });
+        it("Should return template metadata", () => {
+            const metadata = {
+                name: "dummyName",
+                displayName: "dummyDisplayName",
+                version: "1.0",
+                description: "dummyDescription",
+                gitUrl: "dummyUrl",
+                type: "dummyType"
+            };
+
+            return expect(templateService.getTemplateMetaData(packageJson))
+                .to.eventually.be.fulfilled
+                .to.be.an("object")
+                .to.deep.equal(metadata);
+        });
+    });
+
+    describe("Get App template details", () => {
+        let sandbox: any;
+
+        beforeEach(() => {
+            sandbox = sinon.sandbox.create();
+        });
+
+        afterEach(() => sandbox.restore());
+
+        it("Check template details data integrity", () => {
+            const expectedResources = {
+                android: "android",
+                ios: "ios",
+                thumbnail: "dummyThumbnail"
+            };
+
+            sandbox.stub(gitService, "getPackageJsonFromSource")
+                .returns(Promise.resolve(packageJson));
+
+            sandbox.stub(gitService, "getAssetsContent")
+                .returns(Promise.resolve(expectedResources));
+
+            return expect(templateService.getAppTemplateDetails("template-hello-world-ng"))
+                .to.eventually.be.fulfilled
+                .to.be.an("object").then((template: any) => {
+                    expect(template).to.have.property("name", "dummyName");
+                    expect(template).to.have.property("description", "dummyDescription");
+                    expect(template).to.have.property("displayName", "dummyDisplayName");
+                    expect(template).to.have.property("gitUrl", "dummyUrl");
+                    expect(template).to.have.property("version", "1.0");
+                    expect(template).to.have.property("templateFlavor", "JavaScript");
+                    expect(template).to.have.property("type", "dummyType");
+                    expect(template.resources).to.deep.equal(expectedResources);
+                });
+        });
+
+        it("Should be rejected when getPackageJsonFromSource fails", () => {
+            sandbox.stub(gitService, "getPackageJsonFromSource")
+                .returns(Promise.reject(new Error("Error")));
+
+            return expect(templateService.getAppTemplateDetails("template-hello-world-ng"))
+                .to.eventually.be.rejectedWith("Error")
+                .be.an.instanceOf(Error);
+        });
+
+        it("Should be rejected when getAssetsContent fails", () => {
+            sandbox.stub(gitService, "getPackageJsonFromSource")
+                .returns(Promise.resolve(packageJson));
+
+            sandbox.stub(gitService, "getAssetsContent")
+                .returns(Promise.reject(new Error("Error")));
+
+            return expect(templateService.getAppTemplateDetails("template-hello-world-ng"))
+                .to.eventually.be.rejectedWith("Error")
+                .be.an.instanceOf(Error);
         });
     });
 
     describe("Get Available templates", () => {
-        const gitService = new GitService();
-        const templateService = new TemplateService(gitService);
-        it("Returns a Template Details array for all available templates", () => {
-            templateService.getTemplates().then((templates: any) => {
-                should.exist(templates);
-                templates.should.be.an("array");
-                if (templates.length) {
-                    for (let ti = templates.length - 1; ti >= 0; ti--) {
-                        templates[ti].should.have.property("name");
-                        templates[ti].name.should.contain("tns-template-");
-                        templates[ti].should.have.property("version");
-                        templates[ti].should.have.property("description");
-                        templates[ti].should.have.property("templateFlavor");
-                    }
-                }
-            }).catch((err) => {
-                should.not.exist(err);
-            });
+        let sandbox: any;
+
+        beforeEach(() => {
+            sandbox = sinon.sandbox.create();
+        });
+
+        afterEach(() => sandbox.restore());
+
+        it("Should return a Template Details array from cache", () => {
+            templateService.templateCache.set("templateDetails", [appTemplate], 999999);
+
+            return expect(templateService.getTemplates())
+                .to.eventually.be.an("array")
+                .to.have.length(1).then((templates: Array<any>) => {
+                    templates.forEach((template: any) => {
+                        expect(template).to.deep.equal(appTemplate);
+                    });
+                });
+        });
+
+        it("Should return a Template Details array and sets proper cache", () => {
+            const templatesCount = Config.availableTemplateRepos.length;
+            sandbox.stub(templateService, "getAppTemplateDetails")
+                .returns(Promise.resolve(appTemplate));
+
+            return expect(templateService.getTemplates())
+                .to.eventually.be.an("array")
+                .to.have.length(templatesCount).then((templates: Array<any>) => {
+                    templates.forEach((template: any) => {
+                        expect(template).to.deep.equal(appTemplate);
+                    });
+                }).then(() => {
+                    templateService.templateCache.get("templateDetails", (error: any, cachedValue: any) => {
+                        expect(error).to.be.a("null");
+                        expect(cachedValue).to.be.an("array");
+                        expect(cachedValue).to.have.length(templatesCount);
+
+                        cachedValue.forEach((template: any) => {
+                            expect(template).to.deep.equal(appTemplate);
+                        });
+                    });
+                });
+        });
+
+        it("Should return a Template Details array from the backup data", () => {
+            const templatesCount = templateBackup.length;
+
+            sandbox.stub(templateService, "getAppTemplateDetails")
+                .returns(Promise.reject(new Error("Error")));
+
+            return expect(templateService.getTemplates())
+                .to.eventually.be.an("array")
+                .to.have.length(templatesCount).then((templates: Array<any>) => {
+                    expect(templates).to.deep.equal(templateBackup);
+                });
         });
     });
 });

--- a/test/test-template-service.ts
+++ b/test/test-template-service.ts
@@ -211,5 +211,17 @@ describe("TemplateService Api", () => {
                     expect(templates).to.deep.equal(templateBackup);
                 });
         });
+
+        it("Should be rejected if cache template data fails", () => {
+            const templatesCount = templateBackup.length;
+
+            sandbox.stub(templateService.templateCache, "get").yields(new Error("Error"));
+
+            return expect(templateService.getTemplates())
+                .to.eventually.be.an("array")
+                .to.have.length(templatesCount).then((templates: Array<any>) => {
+                    expect(templates).to.deep.equal(templateBackup);
+                });
+        });
     });
 });


### PR DESCRIPTION
To Do list:
- [x] Change backup tests
- [x] Change and extend template service tests
- [x] Create page service tests 

_Note_: There are various ways to implement our tests. I'm just proposing one possible way. I think that the most important thing is to properly consume promises somehow. 

The `.eventually` property from **chaiAsPromised** :`With it, you can transform any existing Chai assertion into one that acts on a promise`

_Resources_: [resource1](https://medium.com/earnest-engineering/testing-promise-rejections-with-chai-as-promised-c65c7c33f329) [resource2](https://www.sitepoint.com/sinon-tutorial-javascript-testing-mocks-spies-stubs/) [resource3](https://semaphoreci.com/community/tutorials/best-practices-for-spies-stubs-and-mocks-in-sinon-js)