### PR TITLE
Bkarastanev/npm install pages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ coverage
 test-reports.xml
 *.tgz
 .vscode
+.idea
 .npmignore
 test/**/*
 tscommand-*.tmp.txt
@@ -12,3 +13,6 @@ tscommand-*.tmp.txt
 tsconfig.json
 tslint.json
 Gruntfile.js
+addPage.js
+getTemplates.js
+xunit.xml

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 
 $injector.require("nsStarterKitsGitService", path.join(__dirname, "services", "nsStarterKitsGitService"));
+$injector.require("nsStarterKitsNpmService", path.join(__dirname, "services", "nsStarterKitsNpmService"));
 $injector.require("nsStarterKitsPageService", path.join(__dirname, "services", "nsStarterKitsPageService"));
 $injector.requirePublicClass("nsStarterKitsTemplateService", path.join(__dirname, "services", "nsStarterKitsTemplateService"));
 $injector.requirePublicClass("nsStarterKitsApplicationService", path.join(__dirname, "services", "nsStarterKitsApplicationService"));

--- a/lib/definitions/nsStarterKitsGitService.d.ts
+++ b/lib/definitions/nsStarterKitsGitService.d.ts
@@ -1,5 +1,4 @@
 interface INsStarterKitsGitService {
     getPackageJsonFromSource(templateName: string): Promise<any>;
     getAssetsContent(templateName: string, versionTag: string): Promise<any>;
-    getPageTemplate(pageName: string, flavor: string, templatesDirectory: string): Promise<string>;
 }

--- a/lib/definitions/nsStarterKitsGitService.d.ts
+++ b/lib/definitions/nsStarterKitsGitService.d.ts
@@ -1,5 +1,5 @@
 interface INsStarterKitsGitService {
     getPackageJsonFromSource(templateName: string): Promise<any>;
     getAssetsContent(templateName: string, versionTag: string): Promise<any>;
-    clonePageTemplate(pageName: string, flavor: string, templatesDirectory: string): Promise<string>;
+    getPageTemplate(pageName: string, flavor: string, templatesDirectory: string): Promise<string>;
 }

--- a/lib/definitions/nsStarterKitsNpmService.d.ts
+++ b/lib/definitions/nsStarterKitsNpmService.d.ts
@@ -1,4 +1,4 @@
 interface INsStarterKitsNpmService {
     getNpmPackageVersion(templateName: string): Promise<any>;
-    installPageTemplateFromNpm(pageName: string, flavor: string, templatesDirectory: string): Promise<any>;
+    installPageTemplate(pageName: string, flavor: string, templatesDirectory: string): Promise<any>;
 }

--- a/lib/definitions/nsStarterKitsNpmService.d.ts
+++ b/lib/definitions/nsStarterKitsNpmService.d.ts
@@ -1,0 +1,4 @@
+interface INsStarterKitsNpmService {
+    getNpmPackageVersion(templateName: string): Promise<any>;
+    installPageTemplateFromNpm(pageName: string, flavor: string, templatesDirectory: string): Promise<any>;
+}

--- a/lib/services/nsStarterKitsGitService.ts
+++ b/lib/services/nsStarterKitsGitService.ts
@@ -44,11 +44,7 @@ export class NsStarterKitsGitService implements INsStarterKitsGitService {
 
         return this.getResourcesFromSource(templateName, assets, version);
     }
-
-    getPageTemplate(pageName: string, flavor: string, templatesDirectory: string): Promise<any> {
-        return this.$nsStarterKitsNpmService.installPageTemplateFromNpm(pageName, flavor, templatesDirectory);
-    }
-
+    
     private getResourcesFromSource(templateName: string, assetDictionary: any, versionTag: string): Promise<any> {
         const promisesMap: Map<string, Promise<any>> = new Map();
 

--- a/lib/services/nsStarterKitsGitService.ts
+++ b/lib/services/nsStarterKitsGitService.ts
@@ -44,7 +44,7 @@ export class NsStarterKitsGitService implements INsStarterKitsGitService {
 
         return this.getResourcesFromSource(templateName, assets, version);
     }
-    
+
     private getResourcesFromSource(templateName: string, assetDictionary: any, versionTag: string): Promise<any> {
         const promisesMap: Map<string, Promise<any>> = new Map();
 

--- a/lib/services/nsStarterKitsGitService.ts
+++ b/lib/services/nsStarterKitsGitService.ts
@@ -1,4 +1,3 @@
-import { Config } from "../shared/config";
 import util from "../shared/util";
 
 const defaultHeaders = {
@@ -6,8 +5,11 @@ const defaultHeaders = {
 };
 
 export class NsStarterKitsGitService implements INsStarterKitsGitService {
+    constructor(private $nsStarterKitsNpmService: INsStarterKitsNpmService) {
+    }
+
     getPackageJsonFromSource(templateName: string): Promise<any> {
-        return this.getNpmPackageVersion(templateName)
+        return this.$nsStarterKitsNpmService.getNpmPackageVersion(templateName)
             .then((packageVersion: string) => {
                 return util.request({
                     method: "GET",
@@ -43,45 +45,8 @@ export class NsStarterKitsGitService implements INsStarterKitsGitService {
         return this.getResourcesFromSource(templateName, assets, version);
     }
 
-    clonePageTemplate(pageName: string, flavor: string, templatesDirectory: string): Promise<any> {
-        return new Promise((resolve, reject) => {
-            const command = "git";
-            const commandArguments: Array<any> = ["clone"];
-            const baseUrl = this.getPageTemplatesBaseUrl(flavor);
-
-            commandArguments.push(`${baseUrl}.git`);
-            commandArguments.push(templatesDirectory);
-
-            const process = util.childProcess.spawn(command, commandArguments);
-            process.on("close", (code) => {
-                if (code !== 0) {
-                    return reject(new Error(`child process exited with code ${code}`));
-                }
-
-                const pagePath = util.path.join(templatesDirectory, pageName);
-                resolve(pagePath);
-            });
-        });
-    }
-
-    private getPageTemplatesBaseUrl(flavor: string): string {
-        let baseUrl: string;
-
-        switch (flavor) {
-            case "JavaScript":
-                baseUrl = util.format(Config.orgBaseUrl, "nativescript-page-templates");
-                break;
-            case "TypeScript":
-                baseUrl = util.format(Config.orgBaseUrl, "nativescript-page-templates-ts");
-                break;
-            case "Angular & TypeScript":
-                baseUrl = util.format(Config.orgBaseUrl, "nativescript-page-templates-ng");
-                break;
-            default:
-                throw new Error("Bad Flavor");
-        }
-
-        return baseUrl;
+    getPageTemplate(pageName: string, flavor: string, templatesDirectory: string): Promise<any> {
+        return this.$nsStarterKitsNpmService.installPageTemplateFromNpm(pageName, flavor, templatesDirectory);
     }
 
     private getResourcesFromSource(templateName: string, assetDictionary: any, versionTag: string): Promise<any> {
@@ -114,32 +79,6 @@ export class NsStarterKitsGitService implements INsStarterKitsGitService {
                     message: "Error retrieving " + templateName + " assets from source",
                     err: error
                 });
-            });
-    }
-
-    private getNpmPackageVersion(templateName: string): Promise<any> {
-        if (templateName.indexOf("tns-") !== 0) {
-            templateName = "tns-" + templateName;
-        }
-
-        return util.request({
-            method: "GET",
-            uri: util.format("https://registry.npmjs.org/%s/", templateName),
-            json: true,
-            resolveWithFullResponse: true,
-            headers: defaultHeaders
-        })
-            .then((response: any) => {
-                let version = "master";
-                if (response.body && response.body["dist-tags"] && response.body["dist-tags"].latest) {
-                    version = "v" + response.body["dist-tags"].latest;
-                }
-
-                return version;
-            })
-            .catch((error: any) => {
-                // fallback to using the master (latest version)
-                return "master";
             });
     }
 }

--- a/lib/services/nsStarterKitsNpmService.ts
+++ b/lib/services/nsStarterKitsNpmService.ts
@@ -1,0 +1,82 @@
+import util from "../shared/util";
+
+const defaultHeaders = {
+    "user-agent": "nativescript-starter-kits"
+};
+
+export class NsStarterKitsNpmService implements INsStarterKitsNpmService {
+    installPageTemplateFromNpm(pageName: string, flavor: string, templatesDirectory: string): Promise<any> {
+        return new Promise((resolve, reject) => {
+            const command = "npm";
+            const commandArguments: Array<any> = ["install"];
+            const options = {cwd: templatesDirectory};
+            let packageName: string;
+
+            try {
+                packageName = this.getPageTemplateNpmName(flavor);
+            } catch (error) {
+                Promise.reject(error);
+            }
+
+            commandArguments.push(packageName);
+           
+            const process = util.childProcess.spawn(command, commandArguments, options);
+            process.on("close", (code) => {
+                if (code !== 0) {
+                    return reject(new Error(`child process exited with code ${code}`));
+                }
+
+                const pagePath = util.path.join(templatesDirectory, "node_modules", packageName, pageName);
+                resolve(pagePath);
+            });
+        });
+    }
+
+    getNpmPackageVersion(templateName: string): Promise<any> {
+        if (templateName.indexOf("tns-") !== 0) {
+            templateName = "tns-" + templateName;
+        }
+
+        return util.request({
+            method: "GET",
+            uri: util.format("https://registry.npmjs.org/%s/", templateName),
+            json: true,
+            resolveWithFullResponse: true,
+            headers: defaultHeaders
+        })
+            .then((response: any) => {
+                let version = "master";
+                if (response.body && response.body["dist-tags"] && response.body["dist-tags"].latest) {
+                    version = "v" + response.body["dist-tags"].latest;
+                }
+
+                return version;
+            })
+            .catch((error: any) => {
+                // fallback to using the master (latest version)
+                return "master";
+            });
+    }
+
+    private getPageTemplateNpmName(flavor: string): string {
+        let packageName: string;
+
+        switch (flavor) {
+            case "JavaScript":
+                packageName = "tns-page-templates";
+                break;
+            case "TypeScript":
+                packageName = "tns-page-templates-ts";
+                break;
+            case "Angular & TypeScript":
+                packageName = "tns-page-templates-ng";
+                break;
+            default:
+                throw new Error("Bad Flavor");
+        }
+
+        return packageName;
+    }
+}
+
+$injector.register("nsStarterKitsNpmService", NsStarterKitsNpmService);

--- a/lib/services/nsStarterKitsNpmService.ts
+++ b/lib/services/nsStarterKitsNpmService.ts
@@ -5,11 +5,11 @@ const defaultHeaders = {
 };
 
 export class NsStarterKitsNpmService implements INsStarterKitsNpmService {
-    installPageTemplateFromNpm(pageName: string, flavor: string, templatesDirectory: string): Promise<any> {
+    installPageTemplate(pageName: string, flavor: string, templatesDirectory: string): Promise<any> {
         return new Promise((resolve, reject) => {
-            const command = "npm";
+            const command: string = (process.platform.indexOf("win") > -1) ? "npm.cmd" : "npm";
             const commandArguments: Array<any> = ["install"];
-            const options = {cwd: templatesDirectory};
+            const options = { cwd: templatesDirectory };
             let packageName: string;
 
             try {
@@ -19,9 +19,9 @@ export class NsStarterKitsNpmService implements INsStarterKitsNpmService {
             }
 
             commandArguments.push(packageName);
-           
-            const process = util.childProcess.spawn(command, commandArguments, options);
-            process.on("close", (code) => {
+
+            const childProcess = util.childProcess.spawn(command, commandArguments, options);
+            childProcess.on("close", (code) => {
                 if (code !== 0) {
                     return reject(new Error(`child process exited with code ${code}`));
                 }

--- a/lib/services/nsStarterKitsPageService.ts
+++ b/lib/services/nsStarterKitsPageService.ts
@@ -22,7 +22,7 @@ export class NsStarterKitsPageService implements INsStarterKitsPageService {
             const displayName = pageTemplate.displayName.toLowerCase();
             const newPageDirectory = util.path.join(appPath, "app");
             const pagesDirectory = util.path.join(__dirname, "../pages");
-            const emptyPackageJson: any = {name: "pageTemplate"};
+            const emptyPackageJson: any = { name: "pageTemplate" };
 
             util.fs.emptyDir(pagesDirectory)
                 .then(() => {
@@ -36,7 +36,7 @@ export class NsStarterKitsPageService implements INsStarterKitsPageService {
                         return Promise.reject(new Error(`Page with the name "${pageName}" already exists`));
                     }
 
-                    return this.$nsStarterKitsNpmService.installPageTemplateFromNpm(displayName, pageTemplate.templateFlavor, pagesDirectory);
+                    return this.$nsStarterKitsNpmService.installPageTemplate(displayName, pageTemplate.templateFlavor, pagesDirectory);
                 })
                 .then((downloadPath: any) => {
                     return this.createPage(downloadPath, newPageDirectory, pageName);

--- a/lib/services/nsStarterKitsPageService.ts
+++ b/lib/services/nsStarterKitsPageService.ts
@@ -22,8 +22,12 @@ export class NsStarterKitsPageService implements INsStarterKitsPageService {
             const displayName = pageTemplate.displayName.toLowerCase();
             const newPageDirectory = util.path.join(appPath, "app");
             const pagesDirectory = util.path.join(__dirname, "../pages");
+            const emptyPackageJson: any = {name: "pageTemplate"};
 
             util.fs.emptyDir(pagesDirectory)
+                .then(() => {
+                    return util.fs.outputJson(util.path.join(pagesDirectory, "package.json"), emptyPackageJson);
+                })
                 .then(() => {
                     return util.pageExists(newPageDirectory, pageName);
                 })
@@ -32,7 +36,7 @@ export class NsStarterKitsPageService implements INsStarterKitsPageService {
                         return Promise.reject(new Error(`Page with the name "${pageName}" already exists`));
                     }
 
-                    return this.$nsStarterKitsGitService.clonePageTemplate(displayName, pageTemplate.templateFlavor, pagesDirectory);
+                    return this.$nsStarterKitsGitService.getPageTemplate(displayName, pageTemplate.templateFlavor, pagesDirectory);
                 })
                 .then((downloadPath: any) => {
                     return this.createPage(downloadPath, newPageDirectory, pageName);

--- a/lib/services/nsStarterKitsPageService.ts
+++ b/lib/services/nsStarterKitsPageService.ts
@@ -8,7 +8,7 @@ const ejs = require("ejs");
 
 export class NsStarterKitsPageService implements INsStarterKitsPageService {
 
-    constructor(private $nsStarterKitsGitService: INsStarterKitsGitService) {
+    constructor(private $nsStarterKitsNpmService: INsStarterKitsNpmService) {
     }
 
     getPages() {
@@ -36,7 +36,7 @@ export class NsStarterKitsPageService implements INsStarterKitsPageService {
                         return Promise.reject(new Error(`Page with the name "${pageName}" already exists`));
                     }
 
-                    return this.$nsStarterKitsGitService.getPageTemplate(displayName, pageTemplate.templateFlavor, pagesDirectory);
+                    return this.$nsStarterKitsNpmService.installPageTemplateFromNpm(displayName, pageTemplate.templateFlavor, pagesDirectory);
                 })
                 .then((downloadPath: any) => {
                     return this.createPage(downloadPath, newPageDirectory, pageName);

--- a/test/test-page-service.ts
+++ b/test/test-page-service.ts
@@ -1,5 +1,4 @@
 import { Yok } from "mobile-cli-lib/yok";
-import { NsStarterKitsGitService } from "../lib/services/nsStarterKitsGitService";
 import { NsStarterKitsNpmService } from "../lib/services/nsStarterKitsNpmService";
 import { NsStarterKitsPageService } from "../lib/services/nsStarterKitsPageService";
 import util from "../lib/shared/util";
@@ -14,7 +13,6 @@ chai.use(chaiAsPromised);
 let testInjector: any;
 
 describe("PageService Api", () => {
-    let gitService: NsStarterKitsGitService;
     let npmService: NsStarterKitsNpmService;
     let pageService: NsStarterKitsPageService;
 
@@ -33,8 +31,7 @@ describe("PageService Api", () => {
 
     beforeEach(() => {
         npmService = new NsStarterKitsNpmService();
-        gitService = new NsStarterKitsGitService(npmService);
-        pageService = new NsStarterKitsPageService(gitService);
+        pageService = new NsStarterKitsPageService(npmService);
         testInjector = new Yok();
 
         testInjector.register("nsStarterKitsPageService", NsStarterKitsPageService);
@@ -72,7 +69,7 @@ describe("PageService Api", () => {
             sandbox.stub(util, "pageExists")
                 .returns(Promise.resolve(false));
 
-            sandbox.stub(gitService, "getPageTemplate")
+            sandbox.stub(npmService, "installPageTemplateFromNpm")
                 .returns(Promise.reject(pageCloneError));
 
             return expect(pageService.addPage(pageName, pageTemplate, appPath))
@@ -90,7 +87,7 @@ describe("PageService Api", () => {
             sandbox.stub(util, "pageExists")
                 .returns(Promise.resolve(false));
 
-            sandbox.stub(gitService, "getPageTemplate")
+            sandbox.stub(npmService, "installPageTemplateFromNpm")
                 .returns(Promise.resolve(clonedPagesDirectory));
 
             sandbox.stub(pageService, "createPage")

--- a/test/test-page-service.ts
+++ b/test/test-page-service.ts
@@ -1,5 +1,6 @@
 import { Yok } from "mobile-cli-lib/yok";
 import { NsStarterKitsGitService } from "../lib/services/nsStarterKitsGitService";
+import { NsStarterKitsNpmService } from "../lib/services/nsStarterKitsNpmService";
 import { NsStarterKitsPageService } from "../lib/services/nsStarterKitsPageService";
 import util from "../lib/shared/util";
 
@@ -14,6 +15,7 @@ let testInjector: any;
 
 describe("PageService Api", () => {
     let gitService: NsStarterKitsGitService;
+    let npmService: NsStarterKitsNpmService;
     let pageService: NsStarterKitsPageService;
 
     const pageName = "dummyPageName";
@@ -30,7 +32,8 @@ describe("PageService Api", () => {
     };
 
     beforeEach(() => {
-        gitService = new NsStarterKitsGitService();
+        npmService = new NsStarterKitsNpmService();
+        gitService = new NsStarterKitsGitService(npmService);
         pageService = new NsStarterKitsPageService(gitService);
         testInjector = new Yok();
 
@@ -69,7 +72,7 @@ describe("PageService Api", () => {
             sandbox.stub(util, "pageExists")
                 .returns(Promise.resolve(false));
 
-            sandbox.stub(gitService, "clonePageTemplate")
+            sandbox.stub(gitService, "getPageTemplate")
                 .returns(Promise.reject(pageCloneError));
 
             return expect(pageService.addPage(pageName, pageTemplate, appPath))
@@ -87,7 +90,7 @@ describe("PageService Api", () => {
             sandbox.stub(util, "pageExists")
                 .returns(Promise.resolve(false));
 
-            sandbox.stub(gitService, "clonePageTemplate")
+            sandbox.stub(gitService, "getPageTemplate")
                 .returns(Promise.resolve(clonedPagesDirectory));
 
             sandbox.stub(pageService, "createPage")

--- a/test/test-page-service.ts
+++ b/test/test-page-service.ts
@@ -69,7 +69,7 @@ describe("PageService Api", () => {
             sandbox.stub(util, "pageExists")
                 .returns(Promise.resolve(false));
 
-            sandbox.stub(npmService, "installPageTemplateFromNpm")
+            sandbox.stub(npmService, "installPageTemplate")
                 .returns(Promise.reject(pageCloneError));
 
             return expect(pageService.addPage(pageName, pageTemplate, appPath))
@@ -87,7 +87,7 @@ describe("PageService Api", () => {
             sandbox.stub(util, "pageExists")
                 .returns(Promise.resolve(false));
 
-            sandbox.stub(npmService, "installPageTemplateFromNpm")
+            sandbox.stub(npmService, "installPageTemplate")
                 .returns(Promise.resolve(clonedPagesDirectory));
 
             sandbox.stub(pageService, "createPage")

--- a/test/test-template-service.ts
+++ b/test/test-template-service.ts
@@ -1,5 +1,6 @@
 import { Yok } from "mobile-cli-lib/yok";
 import { NsStarterKitsGitService } from "../lib/services/nsStarterKitsGitService";
+import { NsStarterKitsNpmService } from "../lib/services/nsStarterKitsNpmService";
 import { NsStarterKitsTemplateService } from "../lib/services/nsStarterKitsTemplateService";
 import { Config } from "../lib/shared/config";
 
@@ -14,6 +15,7 @@ chai.use(chaiAsPromised);
 let testInjector: any;
 
 describe("TemplateService Api", () => {
+    let npmService: NsStarterKitsNpmService;
     let gitService: NsStarterKitsGitService;
     let templateService: NsStarterKitsTemplateService;
 
@@ -44,7 +46,8 @@ describe("TemplateService Api", () => {
     };
 
     beforeEach(() => {
-        gitService = new NsStarterKitsGitService();
+        npmService = new NsStarterKitsNpmService();
+        gitService = new NsStarterKitsGitService(npmService);
         templateService = new NsStarterKitsTemplateService(gitService);
 
         testInjector = new Yok();


### PR DESCRIPTION
This PR introduces a solution to the missing Git dependency on a user machine

Problem: When a user tries to add a page template to his project an error occurs if there is no git installed on the machine

Solution: As npm is a mandatory dependency for NativeScript Side Kick, using it seams like the best solution for the time being:

1. Upload all page templates to NPM
2. Refactor the CLI extension to use npm for installation instead of `git clone`
3. Add a npm service file to handle all npm requests and operations